### PR TITLE
Update emails regexp

### DIFF
--- a/lib/regExp/emails.js
+++ b/lib/regExp/emails.js
@@ -1,5 +1,5 @@
 module.exports = function extractEmails(text) {
-	const regExp = new RegExp('[a-z0-9!#$%&\'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&\'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?', 'gm')
+	const regExp = new RegExp('[a-zA-Z0-9+_.-]+@[a-zA-Z0-9.-]+', 'gm')
 	const emails = []
 	let matches
 


### PR DESCRIPTION
The previous regexp used to take a long time when running it on specific long strings.

As an example, you could try this string
```js
'\tEnsure that companies Quality, Health, Safety & Environment policies & procedures are strictly followed in each and every job'
```
Updated regexp to prevent this.